### PR TITLE
Rework the `hpa` capability

### DIFF
--- a/gits/terminal.py
+++ b/gits/terminal.py
@@ -546,6 +546,9 @@ class Terminal:
         """
 
         p = int(mo.group(1)) - 1
+        if p < 0:
+            p = 0
+
         self._cur_x = min(self._right_most, p)
         self._eol = True if self._cur_x == self._right_most else False
 


### PR DESCRIPTION
The input argument can be equal to 0. `cur_x` will be
set to the input argument - 1 and as a result `cur_x` will be set to -1.
Add the check to prevent such case.