### PR TITLE
Do not let `_cap_cub1` move the cursor one line up

### DIFF
--- a/gits/terminal.py
+++ b/gits/terminal.py
@@ -355,11 +355,6 @@ class Terminal:
         """
         self._cur_x = max(0, self._cur_x - 1)
 
-        if self._cur_x == self._left_most:
-            self._cur_x = self._right_most
-            self._cur_y = max(0, self._cur_y - 1)
-            self._eol = True
-
     def _cap_cud(self, n):
         """Moves the cursor down ``n`` number of lines. """
         self._cur_y = min(self._bottom_most, self._cur_y + n)

--- a/gits/test/helper.py
+++ b/gits/test/helper.py
@@ -291,13 +291,8 @@ class Helper(unittest.TestCase):
 
         term._cap_cub1()
 
-        if cur_x <= 1:
-            self.assertEqual(term._right_most, term._cur_x)
-
-            if cur_y == 0:
-                self.assertEqual(0, term._cur_y)
-            else:
-                self.assertEqual(cur_y - 1, term._cur_y)
+        if cur_x == 0:
+            self.assertEqual(term._left_most, term._cur_x)
         else:
             self.assertEqual(cur_x - 1, term._cur_x)
             self.assertEqual(cur_y, term._cur_y)


### PR DESCRIPTION
It fixes #72.